### PR TITLE
Add guzzle support in package

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,9 @@
             "ArtisansWeb\\ImageOptimize\\": "src/"
         }
     },
-    "require": {},
+    "require": {
+        "guzzlehttp/guzzle": "^6.5"
+    },
     "require-dev": {
         "phpro/grumphp": "^0.17.2",
         "squizlabs/php_codesniffer": "^3.5",


### PR DESCRIPTION
If cURL is not enabled on the server, then as a fallback Guzzle HTTP client will use to interact with resmush APIs.